### PR TITLE
Returns date object instead of hash

### DIFF
--- a/lib/nepali_date_converter.rb
+++ b/lib/nepali_date_converter.rb
@@ -1,7 +1,7 @@
 require 'nepali_date_converter/version'
 require 'nepali_date_converter/calendar'
 
-module NepaliDateConverter
+  module NepaliDateConverter
   class Convert
 
     def self.to_nepali(yy, mm, dd)
@@ -166,6 +166,11 @@ module NepaliDateConverter
           week_day: @numDay
         }
       end
+    end
+    
+    def self.to_english_date(yy, mm, dd)
+      date_hash = self.to_english(yy, mm, dd)
+      Date::strptime("#{date_hash[:year]}-#{date_hash[:month]}-#{date_hash[:date]}", "%Y-%m-%d")
     end
 
   end


### PR DESCRIPTION
Added new function that returns Date object, instead of hash, when converting to English Date